### PR TITLE
Added GpioD dependencies

### DIFF
--- a/pi4j-builder-1.4/Dockerfile
+++ b/pi4j-builder-1.4/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "========================================================="
 # of all Maven build plugins and dependencies.  When complete we will
 # simply delete the project sources from the image and leave the M2
 # repository cache as part of the container image
-RUN git clone --single-branch --branch release/1.4 https://github.com/Pi4J/pi4j /pi4j
+RUN git clone --single-branch --branch release/1.4 https://github.com/Pi4J/pi4j-v1 /pi4j
 RUN cd /pi4j && \
     mvn dependency:resolve dependency:resolve-plugins -DexcludeGroupIds="com.pi4j" -Pnative && \
     rm -R /pi4j

--- a/pi4j-builder-2.0/Dockerfile
+++ b/pi4j-builder-2.0/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "========================================================="
 # repository cache as part of the container image
 RUN git clone --single-branch --branch main https://github.com/Pi4J/pi4j-v2 /pi4j
 RUN cd /pi4j && \
-    mvn dependency:resolve dependency:resolve-plugins -DexcludeGroupIds="com.pi4j" -Pnative && \
+    mvn dependency:go-offline -DexcludeGroupIds=com.pi4j -Pnative && \
     rm -R /pi4j
 
 # ensure read/write access permissions to the M2 repository cache for all users

--- a/pi4j-builder-base/Dockerfile
+++ b/pi4j-builder-base/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get install --yes apt-utils
 
 # install additional build tools and utilities
-RUN apt-get install --yes git build-essential tree nano file curl wget
+RUN apt-get install --yes git build-essential tree nano file curl wget autoconf autoconf-archive libtool pkg-config libgpiod-dev
 
 # install OpenJDK 11 (JDK) and configure JAVA_HOME environment variable
 RUN apt-get install --yes openjdk-11-jdk-headless

--- a/pi4j-builder-base/Dockerfile
+++ b/pi4j-builder-base/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get install --yes apt-utils
 
 # install additional build tools and utilities
-RUN apt-get install --yes git build-essential tree nano file curl wget autoconf autoconf-archive libtool pkg-config libgpiod-dev
+RUN apt-get install --yes git build-essential tree nano file curl wget autoconf autoconf-archive libtool pkg-config libgpiod-dev libgpiod2 gpiod
 
 # install OpenJDK 11 (JDK) and configure JAVA_HOME environment variable
 RUN apt-get install --yes openjdk-11-jdk-headless

--- a/pi4j-builder-base/Dockerfile
+++ b/pi4j-builder-base/Dockerfile
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------------
 # NATIVE BUILDER IMAGE FOR Pi4J (cross-compilers for ARMHF & AARCH64)
 # ---------------------------------------------------------------------------------
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG TARGETARCH
 ARG BUILDDATE
 ARG BUILDVERSION


### PR DESCRIPTION
This PR adds dependencies that are required to build the GpioD extension of this PR: https://github.com/Pi4J/pi4j-v2/pull/322

Note that I couldn't test these changes, since I could not access the built images from my own local image registry. They might not work.